### PR TITLE
Fix Path traversal vulnerability

### DIFF
--- a/lib/servedir.js
+++ b/lib/servedir.js
@@ -94,6 +94,7 @@ var servedir = module.exports = function(root, port, options) {
       };
     }
 
+    req.url = req.url.replace(/(\.\.\/?)/g, '');
     var pathname = decodeURIComponent(parse(req.url).pathname), file = path.join(root, pathname);
 
     // Only allow writing over files if the server can only accept local connections

--- a/lib/servedir.js
+++ b/lib/servedir.js
@@ -95,7 +95,7 @@ var servedir = module.exports = function(root, port, options) {
     }
 
     req.url = req.url.replace(/(\.\.\/?)/g, '');
-    var pathname = decodeURIComponent(parse(req.url).pathname), file = path.join(root, pathname);
+    var pathname = decodeURIComponent(parse(req.url).pathname).replace(/(\.\.\/?)/g, ''), file = path.join(root, pathname);
 
     // Only allow writing over files if the server can only accept local connections
     if (req.method === 'POST' && !options.allowExternalAccess) {


### PR DESCRIPTION
### 📊 Metadata *

servedir is a static file server, this package is vulnerable to Directory Traversal, which may allow access to sensitive files and data on the server.

Affected versions of this package are vulnerable to Directory Traversal.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-secure-servedir/

### ⚙️ Description *

There is no path sanitization making servedir vulnerable against path traversal through the ../ technique, leading to information exposure and file content disclosure.

### 💻 Technical Description *

Fixed by sanitizing any occurrence of ../, using regexp.

### 🐛 Proof of Concept (PoC) *

1. Start the server
`node bin/servedir`
2. Request private file from server
`curl -v --path-as-is http://127.0.0.1:8000/../../../../../../../../../../../home/alex/hacked.txt`
3. Private data will be displayed.

![Captura de pantalla de 2020-09-16 12-35-02](https://user-images.githubusercontent.com/7505980/93319902-1e090580-f819-11ea-88f2-bdf99f9ffd68.png)

### 🔥 Proof of Fix (PoF) *

After fix Response code 404 is returned to user instead of restricted file content

![Captura de pantalla de 2020-09-16 13-14-36](https://user-images.githubusercontent.com/7505980/93324482-a1792580-f81e-11ea-9e88-1dfa860dce51.png)


### 👍 User Acceptance Testing (UAT)

After fix functionality is unafected
![Captura de pantalla de 2020-09-16 12-36-32](https://user-images.githubusercontent.com/7505980/93320077-501a6780-f819-11ea-8008-d01994f7c963.png)
